### PR TITLE
Fix `'HTTPException' object has no attribute 'reason'` error

### DIFF
--- a/sentry_phabricator/plugin.py
+++ b/sentry_phabricator/plugin.py
@@ -117,7 +117,7 @@ class PhabricatorPlugin(IssuePlugin):
         except phabricator.APIError, e:
             raise forms.ValidationError('%s %s' % (e.code, e.message))
         except httplib.HTTPException, e:
-            raise forms.ValidationError('Unable to reach Phabricator host: %s' % (e.reason,))
+            raise forms.ValidationError('Unable to reach Phabricator host: %s' % (e.message,))
 
         return data['id']
 


### PR DESCRIPTION
It does not look like `HTTPException` has a `reason`, but it does
inherit from `Exception` so it should have a `message`.